### PR TITLE
Fixing SLEEP_LED_ENABLE

### DIFF
--- a/keyboard/kc60/Makefile.pjrc
+++ b/keyboard/kc60/Makefile.pjrc
@@ -90,7 +90,7 @@ MOUSEKEY_ENABLE = yes	# Mouse keys(+5000)
 EXTRAKEY_ENABLE = yes	# Audio control and System control(+600)
 CONSOLE_ENABLE = yes    # Console for debug
 COMMAND_ENABLE = yes    # Commands for debug and configuration
-SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
+#SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 NKRO_ENABLE = yes	# USB Nkey Rollover(+500)
 #PS2_MOUSE_ENABLE = yes	# PS/2 mouse(TrackPoint) support
 


### PR DESCRIPTION
By default the sleep_led_enable flag here is enabled, however in the makefile it is disabled, resulting in the flag being enabled when the firmware is compiled. 

Commenting out the SLEEP_LED_ENABLE ensures that the breathing sleep LED during USB suspend only occurs if it is uncommented in Makefile
