### PR TITLE
added default implementation of backlight_action

### DIFF
--- a/tmk_core/common/backlight.c
+++ b/tmk_core/common/backlight.c
@@ -86,5 +86,5 @@ void backlight_level(uint8_t level)
 
 void backlight_action(void)
 {
-    dprintf("backlight action (tmk_core/common/backlight.c)\n");
+    //dprintf("backlight action (tmk_core/common/backlight.c)\n");
 }

--- a/tmk_core/common/backlight.c
+++ b/tmk_core/common/backlight.c
@@ -83,3 +83,8 @@ void backlight_level(uint8_t level)
     eeconfig_write_backlight(backlight_config.raw);
     backlight_set(backlight_config.level);
 }
+
+void backlight_action(void)
+{
+    dprintf("backlight action (tmk_core/common/backlight.c)\n");
+}


### PR DESCRIPTION
Not sure what backlight_action is used for, but it is defined in
tmk_core/common/backlight.h and didn't have a corresponding default
implementation in tmk_core/common/backlight.c

The following keyboards wouldn't compile with `BACKLIGHT_ENABLE = yes`:

```
tmk_keyboard$ find keyboard/ -name backlight.c | xargs grep -L "backlight_action"
keyboard/ble60/backlight.c
keyboard/epbt60/backlight.c
keyboard/kc60/backlight.c
keyboard/kmac/backlight.c
keyboard/lightpad/backlight.c
keyboard/lightsaber/backlight.c
keyboard/nerd/backlight.c
```
